### PR TITLE
Abortable module enable and request handling

### DIFF
--- a/modules/common/inc/BaseModule.h
+++ b/modules/common/inc/BaseModule.h
@@ -128,11 +128,12 @@ public:
         SetModuleState(ModuleState::Enabling);
         try {
             co_await OnEnable();
-            if (GetModuleState() != ModuleState::Enabling) {
+            const ModuleState currentState = GetModuleState();
+            if (currentState != ModuleState::Enabling) {
                 Debug::LogWarning(
                     "{}: Enable completion ignored - state changed to {}",
                     GetModuleName(),
-                    magic_enum::enum_name(GetModuleState())
+                    magic_enum::enum_name(currentState)
                 );
                 co_return;
             }
@@ -151,7 +152,7 @@ public:
         const std::shared_ptr<BaseModule> instance = shared_from_this();
         const ModuleState state = GetModuleState();
 
-        if (state != ModuleState::Enabled) {
+        if (state != ModuleState::Enabled && state != ModuleState::Enabling) {
             if (disableWarnings) {
                 co_return;
             }
@@ -160,7 +161,12 @@ public:
             co_return;
         }
 
-        Debug::Log("{}: Disable started", GetModuleName());
+        if (state == ModuleState::Enabling) {
+            Debug::Log("{}: Disable started - cancelling enable in progress", GetModuleName());
+        } else {
+            Debug::Log("{}: Disable started", GetModuleName());
+        }
+
         SetModuleState(ModuleState::Disabling);
         try {
             co_await OnDisable();
@@ -196,15 +202,11 @@ public:
             co_return;
         }
 
-        if (state == ModuleState::Enabling) {
-            SetModuleState(ModuleState::Disabling);
-        }
-
         Debug::Log("{}: Shutdown started", GetModuleName());
         DisableResponseCallbacks();
 
-        if (GetModuleState() == ModuleState::Enabled) {
-            co_await DisableAwaitable();
+        if (state == ModuleState::Enabled || state == ModuleState::Enabling) {
+            co_await DisableAwaitable(true);
         }
 
         try {
@@ -241,6 +243,11 @@ protected:
     std::atomic<ModuleState> m_state = ModuleState::Uninitialized;
     std::atomic<bool> m_peerModuleEnabled = false;
     mutable std::atomic<ModuleFailReason> m_failReason = ModuleFailReason::None;
+
+    bool ShouldAbortEnable() const {
+        const ModuleState state = GetModuleState();
+        return state != ModuleState::Enabling && state != ModuleState::Enabled;
+    }
 
     virtual void EnableResponseCallbacks() = 0;
     virtual void DisableResponseCallbacks() = 0;

--- a/modules/file-share/desktop/inc/FileShareModule.h
+++ b/modules/file-share/desktop/inc/FileShareModule.h
@@ -3,6 +3,8 @@
 
 #include <vector>
 #include <memory>
+#include <mutex>
+#include <unordered_set>
 
 #include <BaseModule.h>
 #include <TransferChannel.h>
@@ -26,6 +28,9 @@ public:
     void FetchEntryIcon(const FileEntry& entry, FileIconDensity density) const;
 
 private:
+    bool TryBeginDirectoryRequest(const std::string& path) const;
+    void EndDirectoryRequest(const std::string& path) const;
+
     asio::awaitable<void> FetchDirectoryEntriesAwaitable(std::string path) const;
     asio::awaitable<std::vector<FileEntry>> FetchDirectoryEntriesAwaitable(std::string path);
     asio::awaitable<void> FetchEntryAwaitable(FileEntry entry, std::string destination) const;
@@ -34,6 +39,8 @@ private:
     static asio::awaitable<void> FetchEntryIconAwaitable(FileEntry entry, FileIconDensity density);
 
     std::vector<std::shared_ptr<TransferChannel>> m_transferChannels;
+    mutable std::mutex m_directoryRequestMutex;
+    mutable std::unordered_set<std::string> m_inFlightDirectoryRequests;
 
 protected:
     void EnableResponseCallbacks() override;

--- a/modules/file-share/desktop/src/FileShareModule.cpp
+++ b/modules/file-share/desktop/src/FileShareModule.cpp
@@ -27,9 +27,25 @@ constexpr size_t PROGRESS_EVENT_DELAY_MS = 100;
 
 FileShareModule::FileShareModule() = default;
 
+bool FileShareModule::TryBeginDirectoryRequest(const std::string& path) const {
+    std::lock_guard<std::mutex> lock(m_directoryRequestMutex);
+    const auto [_, inserted] = m_inFlightDirectoryRequests.insert(path);
+    return inserted;
+}
+
+void FileShareModule::EndDirectoryRequest(const std::string& path) const {
+    std::lock_guard<std::mutex> lock(m_directoryRequestMutex);
+    m_inFlightDirectoryRequests.erase(path);
+}
+
 void FileShareModule::FetchDirectoryEntries(const std::string& path) const {
     if (path.empty()) {
         Debug::LogWarning("FileShareModule: Fetch directory entries skipped: empty path");
+        return;
+    }
+
+    if (!TryBeginDirectoryRequest(path)) {
+        Debug::LogWarning("FileShareModule: Fetch directory entries skipped: request already in-flight for {}", path);
         return;
     }
 
@@ -45,6 +61,11 @@ void FileShareModule::FetchDirectoryEntries(const FileEntry& entry) const {
         return;
     }
 
+    if (!TryBeginDirectoryRequest(path)) {
+        Debug::LogWarning("FileShareModule: Fetch directory entries skipped: request already in-flight for {}", path);
+        return;
+    }
+
     Debug::Log("FileShareModule: Fetching directory entries for {}", path);
     asio::co_spawn(m_context, FetchDirectoryEntriesAwaitable(std::move(path)), asio::detached);
 }
@@ -52,6 +73,10 @@ void FileShareModule::FetchDirectoryEntries(const FileEntry& entry) const {
 asio::awaitable<void> FileShareModule::FetchDirectoryEntriesAwaitable(std::string path) const {
     const std::shared_ptr<const BaseModule> instance = shared_from_this();
     std::string requestPath = path;
+    const auto guard = std::shared_ptr<void>(nullptr, [this, path](void*) {
+        EndDirectoryRequest(path);
+    });
+    (void)guard;
 
     const std::optional<PC_Package> response = co_await ConnectionManager::SendRequest(
         PC_PackageType::FILE_SHARE_DIRECTORY_ENTRIES_REQUEST,
@@ -460,6 +485,10 @@ void FileShareModule::DisableResponseCallbacks() {
 
 void FileShareModule::OnInitialize() {
     m_peerModuleEnabled.store(false);
+    {
+        std::lock_guard<std::mutex> lock(m_directoryRequestMutex);
+        m_inFlightDirectoryRequests.clear();
+    }
     m_transferChannels.clear();
     m_transferChannels.reserve(TRANSFER_CHANNELS_COUNT);
 
@@ -498,6 +527,10 @@ asio::awaitable<void> FileShareModule::OnEnable() {
     asio::steady_timer timer(m_context);
     const auto peerEnableDeadline = std::chrono::steady_clock::now() + std::chrono::seconds(10);
     while (!m_peerModuleEnabled.load()) {
+        if (ShouldAbortEnable()) {
+            co_return;
+        }
+
         if (std::chrono::steady_clock::now() >= peerEnableDeadline) {
             throw std::runtime_error("FileShareModule enable timed out waiting for peer module acknowledgement");
         }
@@ -508,6 +541,9 @@ asio::awaitable<void> FileShareModule::OnEnable() {
 
     for (int i = 0; i < m_transferChannels.size(); ++i) {
         co_await ports[i].first->Wait();
+        if (ShouldAbortEnable()) {
+            co_return;
+        }
         ConnectionManager::Send(PC_PackageType::CONNECTION_CHANNEL_CONNECTION_PORT_INFO, ports[i].second);
     }
 
@@ -540,6 +576,10 @@ asio::awaitable<void> FileShareModule::OnEnable() {
 
 asio::awaitable<void> FileShareModule::OnDisable() {
     m_peerModuleEnabled.store(false);
+    {
+        std::lock_guard<std::mutex> lock(m_directoryRequestMutex);
+        m_inFlightDirectoryRequests.clear();
+    }
     ConnectionManager::Send(PC_PackageType::FILE_SHARE_MODULE_DISABLE);
     for (size_t i = 0; i < m_transferChannels.size(); ++i) {
         asio::co_spawn(m_context, m_transferChannels[i]->Disconnect(), asio::detached);
@@ -550,6 +590,10 @@ asio::awaitable<void> FileShareModule::OnDisable() {
 
 asio::awaitable<void> FileShareModule::OnShutdown() {
     m_peerModuleEnabled.store(false);
+    {
+        std::lock_guard<std::mutex> lock(m_directoryRequestMutex);
+        m_inFlightDirectoryRequests.clear();
+    }
     m_transferChannels.clear();
     co_return;
 }

--- a/modules/file-share/mobile/inc/FileShareModule.h
+++ b/modules/file-share/mobile/inc/FileShareModule.h
@@ -3,11 +3,15 @@
 
 #include <vector>
 #include <memory>
+#include <future>
+#include <mutex>
+#include <unordered_map>
 
 #include <BaseModule.h>
 #include <TransferChannel.h>
 #include <ConnectionManager.h>
 #include <FileIconDensity.h>
+#include <FileSystemManager.h>
 
 class FileShareModule final : public BaseModule {
 public:
@@ -15,11 +19,17 @@ public:
     void PostEntry(const std::filesystem::path& path, const std::filesystem::path& destination) const;
 
 private:
+    std::shared_future<DirectoryResult> GetOrCreateDirectoryScanFuture(const std::string& path);
+    void CleanupDirectoryScanFutureIfReady(const std::string& path);
+    void ClearDirectoryScanFutures();
+
     asio::awaitable<void> PostEntryAwaitable(std::filesystem::path path, std::filesystem::path destination) const;
     std::vector<uint8_t> GetEntryIcon(const std::string& file, FileIconDensity density);
 
     std::atomic_size_t m_transferChannelInitializationIndex;
     std::vector<std::shared_ptr<TransferChannel>> m_transferChannels;
+    std::mutex m_directoryScanMutex;
+    std::unordered_map<std::string, std::shared_future<DirectoryResult>> m_directoryScanFutures;
 
 protected:
     void EnableResponseCallbacks() override;

--- a/modules/file-share/mobile/src/FileShareModule.cpp
+++ b/modules/file-share/mobile/src/FileShareModule.cpp
@@ -19,8 +19,43 @@
 
 constexpr size_t TRANSFER_CHANNELS_COUNT = 10;
 constexpr size_t PROGRESS_EVENT_DELAY_MS = 100;
+constexpr size_t DIRECTORY_REQUEST_WAIT_POLL_MS = 5;
 
 FileShareModule::FileShareModule() = default;
+
+std::shared_future<DirectoryResult> FileShareModule::GetOrCreateDirectoryScanFuture(const std::string& path) {
+    std::lock_guard<std::mutex> lock(m_directoryScanMutex);
+    const auto it = m_directoryScanFutures.find(path);
+    if (it != m_directoryScanFutures.end()) {
+        return it->second;
+    }
+
+    const std::filesystem::path filesystemPath(path);
+    std::future<DirectoryResult> future = ThreadPool::PostFuture([filesystemPath]() {
+        return FileSystemManager::GetEntries(filesystemPath);
+    });
+
+    std::shared_future<DirectoryResult> sharedFuture = future.share();
+    m_directoryScanFutures.insert_or_assign(path, sharedFuture);
+    return sharedFuture;
+}
+
+void FileShareModule::CleanupDirectoryScanFutureIfReady(const std::string& path) {
+    std::lock_guard<std::mutex> lock(m_directoryScanMutex);
+    const auto it = m_directoryScanFutures.find(path);
+    if (it == m_directoryScanFutures.end()) {
+        return;
+    }
+
+    if (it->second.wait_for(std::chrono::milliseconds(0)) == std::future_status::ready) {
+        m_directoryScanFutures.erase(it);
+    }
+}
+
+void FileShareModule::ClearDirectoryScanFutures() {
+    std::lock_guard<std::mutex> lock(m_directoryScanMutex);
+    m_directoryScanFutures.clear();
+}
 
 void FileShareModule::PostEntry(const std::filesystem::path& path, const std::filesystem::path& destination) const {
     asio::co_spawn(m_context, PostEntryAwaitable(path, destination), asio::detached);
@@ -193,14 +228,46 @@ void FileShareModule::EnableResponseCallbacks() {
     ConnectionManager::AddResponseHandler(PC_PackageType::FILE_SHARE_MODULE_DISABLE, [instance, this](PC_Package&& package) mutable {
        Disable(true);
     });
-	ConnectionManager::AddResponseHandler(PC_PackageType::FILE_SHARE_DIRECTORY_ENTRIES_REQUEST, [instance, this](PC_Package&& package) mutable {
+	ConnectionManager::AddAwaitableResponseHandler(PC_PackageType::FILE_SHARE_DIRECTORY_ENTRIES_REQUEST, [instance, this](PC_Package&& package) mutable -> asio::awaitable<void> {
 	    const size_t requestID    = package->GetValue<size_t>();
 	    const std::string pathStr = package->GetValue<std::string>();
         Debug::Log("FileShareModule: Received directory entries request. RequestID: {}, Path: {}", requestID, pathStr);
 
-	    const std::filesystem::path path(pathStr);
-	    auto [entries, success] = FileSystemManager::GetEntries(path);
-	    ConnectionManager::SendRequestResponse(requestID, PC_PackageType::FILE_SHARE_DIRECTORY_ENTRIES_RESPONSE, std::move(entries));
+        const std::shared_future<DirectoryResult> scanFuture = GetOrCreateDirectoryScanFuture(pathStr);
+
+        asio::steady_timer timer(m_context);
+        while (scanFuture.wait_for(std::chrono::milliseconds(0)) != std::future_status::ready) {
+            timer.expires_after(std::chrono::milliseconds(DIRECTORY_REQUEST_WAIT_POLL_MS));
+            co_await timer.async_wait();
+        }
+
+        DirectoryResult result;
+        try {
+            result = scanFuture.get();
+        } catch (const std::exception& exc) {
+            Debug::LogError(
+                "FileShareModule: Directory scan failed with exception. RequestID: {}, Path: {}, Error: {}",
+                requestID,
+                pathStr,
+                exc.what()
+            );
+            ProcessError(ModuleFailReason::InternalError);
+            ConnectionManager::SendRequestResponse(
+                requestID,
+                PC_PackageType::FILE_SHARE_DIRECTORY_ENTRIES_RESPONSE,
+                std::vector<FileEntry>{}
+            );
+            CleanupDirectoryScanFutureIfReady(pathStr);
+            co_return;
+        }
+
+        CleanupDirectoryScanFutureIfReady(pathStr);
+
+        ConnectionManager::SendRequestResponse(
+            requestID,
+            PC_PackageType::FILE_SHARE_DIRECTORY_ENTRIES_RESPONSE,
+            std::move(result.entries)
+        );
 	});
     ConnectionManager::AddAwaitableResponseHandler(PC_PackageType::FILE_SHARE_TRANSFER_FETCH_REQUEST, [instance, this](PC_Package&& package) mutable -> asio::awaitable<void> {
         const size_t requestID = package->GetValue<size_t>();
@@ -409,7 +476,7 @@ void FileShareModule::EnableResponseCallbacks() {
 }
 
 void FileShareModule::DisableResponseCallbacks() {
-    ConnectionManager::RemoveResponseHandler(PC_PackageType::FILE_SHARE_DIRECTORY_ENTRIES_REQUEST);
+    ConnectionManager::RemoveAwaitableResponseHandler(PC_PackageType::FILE_SHARE_DIRECTORY_ENTRIES_REQUEST);
     ConnectionManager::RemoveAwaitableResponseHandler(PC_PackageType::FILE_SHARE_TRANSFER_FETCH_REQUEST);
     ConnectionManager::RemoveAwaitableResponseHandler(PC_PackageType::FILE_SHARE_TRANSFER_POST_REQUEST);
     ConnectionManager::RemoveAwaitableResponseHandler(PC_PackageType::CONNECTION_CHANNEL_CONNECTION_PORT_INFO);
@@ -420,6 +487,7 @@ void FileShareModule::DisableResponseCallbacks() {
 }
 
 void FileShareModule::OnInitialize() {
+    ClearDirectoryScanFutures();
     m_transferChannels.reserve(TRANSFER_CHANNELS_COUNT);
     std::shared_ptr<SSLContext> sslContext = ConnectionManager::GetSSLContextClient();
     for (int i = 0; i < TRANSFER_CHANNELS_COUNT; ++i) {
@@ -436,11 +504,19 @@ asio::awaitable<void> FileShareModule::OnEnable() {
         co_return;
     }
 
+    if (ShouldAbortEnable()) {
+        co_return;
+    }
+
     m_transferChannelInitializationIndex.store(0);
     ConnectionManager::Send(PC_PackageType::FILE_SHARE_MODULE_ENABLE);
 
     asio::steady_timer timer(m_context);
     while (!m_peerModuleEnabled.load()) {
+        if (ShouldAbortEnable()) {
+            co_return;
+        }
+
         timer.expires_after(std::chrono::milliseconds(10));
         co_await timer.async_wait();
     }
@@ -448,6 +524,7 @@ asio::awaitable<void> FileShareModule::OnEnable() {
 
 asio::awaitable<void> FileShareModule::OnDisable() {
     m_peerModuleEnabled.store(false);
+    ClearDirectoryScanFutures();
     ConnectionManager::Send(PC_PackageType::FILE_SHARE_MODULE_DISABLE);
     for (size_t i = 0; i < m_transferChannels.size(); ++i) {
         asio::co_spawn(m_context, m_transferChannels[i]->Disconnect(), asio::detached);
@@ -458,6 +535,7 @@ asio::awaitable<void> FileShareModule::OnDisable() {
 
 asio::awaitable<void> FileShareModule::OnShutdown() {
     m_peerModuleEnabled.store(false);
+    ClearDirectoryScanFutures();
     m_transferChannels.clear();
     co_return;
 }

--- a/modules/network-camera/desktop/src/NetworkCameraModule.cpp
+++ b/modules/network-camera/desktop/src/NetworkCameraModule.cpp
@@ -526,6 +526,10 @@ asio::awaitable<void> NetworkCameraModule::OnEnable() {
 
     {
         const std::optional<PC_Package> response = co_await ConnectionManager::SendRequest(PC_PackageType::NETWORK_CAMERA_MODULE_REQUEST_REMOTE_KEY, std::vector(m_localKey));
+        if (ShouldAbortEnable()) {
+            co_return;
+        }
+
         if (!response.has_value()) {
             Debug::LogError("No response");
             ProcessError(ModuleFailReason::Timeout);
@@ -545,6 +549,10 @@ asio::awaitable<void> NetworkCameraModule::OnEnable() {
         std::string cameraID = m_cameraSettings.id;
 
         const std::optional<PC_Package> response = co_await ConnectionManager::SendRequest(PC_PackageType::NETWORK_CAMERA_MODULE_REQUEST_START_STREAM, std::move(cameraID), std::move(cameraFormat));
+        if (ShouldAbortEnable()) {
+            co_return;
+        }
+
         if (!response.has_value()) {
             Debug::LogError("No response");
             ProcessError(ModuleFailReason::Timeout);
@@ -561,11 +569,18 @@ asio::awaitable<void> NetworkCameraModule::OnEnable() {
 
     asio::steady_timer timer(m_context);
     while (!m_peerModuleEnabled.load()) {
+        if (ShouldAbortEnable()) {
+            co_return;
+        }
+
         timer.expires_after(std::chrono::milliseconds(10));
         co_await timer.async_wait();
     }
 
     co_await StartStream();
+    if (ShouldAbortEnable()) {
+        co_return;
+    }
 
     ConnectionManager::Send(PC_PackageType::NETWORK_CAMERA_MODULE_STATE_CHANGED, true);
 }

--- a/modules/network-camera/mobile/src/NetworkCameraModule.cpp
+++ b/modules/network-camera/mobile/src/NetworkCameraModule.cpp
@@ -195,6 +195,10 @@ asio::awaitable<void> NetworkCameraModule::OnEnable() {
         co_return;
     }
 
+    if (ShouldAbortEnable()) {
+        co_return;
+    }
+
 #ifdef ANDROID_DEVICE
     UpdateMainServiceCameraRequest(true);
 #endif
@@ -203,6 +207,10 @@ asio::awaitable<void> NetworkCameraModule::OnEnable() {
 
     asio::steady_timer timer(m_context);
     while (!m_peerModuleEnabled.load()) {
+        if (ShouldAbortEnable()) {
+            co_return;
+        }
+
         timer.expires_after(std::chrono::milliseconds(10));
         co_await timer.async_wait();
     }

--- a/modules/notification-sync/desktop/src/NotificationSyncModule.cpp
+++ b/modules/notification-sync/desktop/src/NotificationSyncModule.cpp
@@ -228,6 +228,10 @@ asio::awaitable<void> NotificationSyncModule::OnEnable() {
         co_await previousChannel->Disconnect();
     }
 
+    if (ShouldAbortEnable()) {
+        co_return;
+    }
+
     const std::shared_ptr<NotificationTransferChannel> channel = std::make_shared<NotificationTransferChannel>(ConnectionManager::GetSSLContextServer(), m_context);
     SetChannel(channel);
 
@@ -236,11 +240,19 @@ asio::awaitable<void> NotificationSyncModule::OnEnable() {
 
     asio::co_spawn(m_context, channel->Seek(flag, port), asio::detached);
     co_await flag.Wait();
+    if (ShouldAbortEnable()) {
+        co_return;
+    }
+
     Debug::Log("Notification channel seek opened local port {}", port);
     ConnectionManager::Send(PC_PackageType::NOTIFICATION_SYNC_MODULE_CONNECTION_PORT_INFO, port);
 
     asio::steady_timer timer(m_context.get_executor());
     while (channel->GetConnectionState() != ConnectionState::CONNECTED) {
+        if (ShouldAbortEnable()) {
+            co_return;
+        }
+
         if (GetChannel() != channel) {
             co_return;
         }
@@ -256,11 +268,19 @@ asio::awaitable<void> NotificationSyncModule::OnEnable() {
     Debug::Log("Notification channel connected");
 
     while (!m_peerModuleEnabled.load()) {
+        if (ShouldAbortEnable()) {
+            co_return;
+        }
+
         timer.expires_after(std::chrono::milliseconds(10));
         co_await timer.async_wait();
     }
 
     co_await FetchNotificationList();
+    if (ShouldAbortEnable()) {
+        co_return;
+    }
+
     ConnectionManager::Send(PC_PackageType::NOTIFICATION_SYNC_MODULE_STATE_CHANGE, true);
 }
 

--- a/modules/notification-sync/mobile/src/NotificationSyncModule.cpp
+++ b/modules/notification-sync/mobile/src/NotificationSyncModule.cpp
@@ -188,10 +188,22 @@ asio::awaitable<void> NotificationSyncModule::OnEnable() {
         );
     }
 
+    if (ShouldAbortEnable()) {
+        co_return;
+    }
+
     ConnectionManager::Send(PC_PackageType::NOTIFICATION_SYNC_MODULE_ENABLE);
     if (co_await m_connectedFlag.WaitFor(std::chrono::seconds(5)) == AwaitableFlag::Result::TIMEOUT) {
+        if (ShouldAbortEnable()) {
+            co_return;
+        }
+
         ProcessError(ModuleFailReason::Timeout);
         Disable();
+        co_return;
+    }
+
+    if (ShouldAbortEnable()) {
         co_return;
     }
 
@@ -199,6 +211,10 @@ asio::awaitable<void> NotificationSyncModule::OnEnable() {
 
     asio::steady_timer timer(m_context.get_executor());
     while (!m_peerModuleEnabled.load()) {
+        if (ShouldAbortEnable()) {
+            co_return;
+        }
+
         timer.expires_after(std::chrono::milliseconds(10));
         co_await timer.async_wait();
     }

--- a/utilities/p2p-network/inc/ConnectionManager.h
+++ b/utilities/p2p-network/inc/ConnectionManager.h
@@ -5,6 +5,7 @@
 #include <filesystem>
 #include <Packable.h>
 #include <optional>
+#include <chrono>
 
 #include <QObject>
 #include <PrimaryConnection.h>
@@ -67,8 +68,13 @@ public:
 
         s_instance->m_requestAwaitableMap.InsertOrAssign(requestID, flag);
         s_instance->m_primaryConnection->SendWithFlag(type, packageFlag, static_cast<size_t>(requestID), std::forward<Args>(args)...);
-        co_await flag->Wait();
+        const AwaitableFlag::Result waitResult = co_await flag->WaitFor(REQUEST_TIMEOUT);
         s_instance->m_requestAwaitableMap.Erase(requestID);
+
+        if (waitResult != AwaitableFlag::Result::SUCCESS) {
+            s_instance->m_requestPackageMap.Erase(requestID);
+            co_return std::nullopt;
+        }
 
         co_return s_instance->m_requestPackageMap.Pop(requestID);
     }
@@ -93,8 +99,11 @@ private:
     static std::shared_ptr<SSLContext> CreateSSLContext(bool isServer, uuid targetUUID = boost::uuids::nil_uuid(), bool allowUnpinnedPairing = false);
     static void RunContext();
     static void SetSeekingEndpoint(TCPEndpoint endpoint);
+    static void CancelPendingRequests();
 
     asio::awaitable<void> CoProcessPackages();
+
+    static constexpr std::chrono::seconds REQUEST_TIMEOUT{30};
 
     static ConnectionManager* s_instance;
     static std::mutex         s_mutex;

--- a/utilities/p2p-network/inc/PrimaryConnection.h
+++ b/utilities/p2p-network/inc/PrimaryConnection.h
@@ -63,6 +63,7 @@ private:
     asio::awaitable<void> CoReceive();
     asio::awaitable<void> CoSendHeartbeat();
     asio::awaitable<void> CoHeartbeatMonitor();
+    void ClearQueuedPackages();
 
     static void SavePairData(const InitialConnectionData& data);
     void SaveCertificate(const InitialConnectionData& data) const;

--- a/utilities/p2p-network/src/ConnectionManager.cpp
+++ b/utilities/p2p-network/src/ConnectionManager.cpp
@@ -229,11 +229,35 @@ void ConnectionManager::Disconnect(const std::error_code errorCode) {
     std::call_once(s_flag, Initialize);
     Debug::Log("ConnectionManager: Disconnecting primary connection. Reason: {}", errorCode.message());
 
+    CancelPendingRequests();
     s_instance->m_primaryConnection->Disconnect(errorCode, true);
 
     std::lock_guard<std::mutex> lock(s_mutex);
     if (s_instance->m_initialConnectionOut != nullptr) {
         s_instance->m_initialConnectionOut->Disconnect();
+    }
+}
+
+void ConnectionManager::CancelPendingRequests() {
+    if (s_instance == nullptr) {
+        return;
+    }
+
+    std::vector<std::shared_ptr<AwaitableFlag>> pendingFlags = s_instance->m_requestAwaitableMap.PopAll();
+    const size_t droppedResponses = s_instance->m_requestPackageMap.PopAll().size();
+
+    for (const std::shared_ptr<AwaitableFlag>& flag : pendingFlags) {
+        if (flag) {
+            flag->Signal();
+        }
+    }
+
+    if (!pendingFlags.empty() || droppedResponses > 0) {
+        Debug::LogWarning(
+            "ConnectionManager: Canceled {} pending requests and dropped {} pending responses",
+            pendingFlags.size(),
+            droppedResponses
+        );
     }
 }
 
@@ -327,7 +351,6 @@ asio::awaitable<void> ConnectionManager::CoProcessPackages() {
     while (true) {
         try {
             co_await receiveFlag->Wait();
-            receiveFlag->Reset();
 
             std::optional<std::unique_ptr<Package<PC_PackageType>>> packageOptional = m_primaryConnection->GetPackage();
             while (packageOptional.has_value()) {
@@ -482,14 +505,12 @@ void ConnectionManager::SendEvent(const std::unique_ptr<QEvent>& event) {
         });
 
         if (objects.empty()) {
-            Debug::Log("ConnectionManager: SendEvent called but no active listeners registered");
             return;
         }
 
         targets = objects;
     }
 
-    Debug::Log("ConnectionManager: Dispatching event to {} listeners", targets.size());
     for (const auto& obj : targets) {
         if (obj.isNull()) {
             continue;

--- a/utilities/p2p-network/src/InitialConnection.cpp
+++ b/utilities/p2p-network/src/InitialConnection.cpp
@@ -155,6 +155,7 @@ asio::awaitable<void> InitialConnection::CoDisconnect(const bool cancelSeeking) 
 
     Debug::Log("InitialConnection: Closing socket and cleaning up...");
     m_connectionState = ConnectionState::DISCONNECTING;
+    m_sendFlag.Signal();
 
     if (m_socket.is_open()) {
         std::error_code ec;
@@ -190,7 +191,6 @@ asio::awaitable<void> InitialConnection::CoSend() {
         while (m_connectionState == ConnectionState::CONNECTED) {
             if (m_packagesOut.empty()) {
                 co_await m_sendFlag.Wait();
-                m_sendFlag.Reset();
             }
 
             if (m_connectionState != ConnectionState::CONNECTED) break;

--- a/utilities/p2p-network/src/PrimaryConnection.cpp
+++ b/utilities/p2p-network/src/PrimaryConnection.cpp
@@ -89,7 +89,17 @@ std::shared_ptr<AwaitableFlag> PrimaryConnection::GetReceiveFlag() const {
 }
 
 IPAddress PrimaryConnection::GetPeerAddress() const {
-    return m_socket->lowest_layer().remote_endpoint().address();
+    if (!m_socket || !m_socket->lowest_layer().is_open()) {
+        return {};
+    }
+
+    std::error_code errorCode;
+    const TCPEndpoint endpoint = m_socket->lowest_layer().remote_endpoint(errorCode);
+    if (errorCode) {
+        return {};
+    }
+
+    return endpoint.address();
 }
 
 bool PrimaryConnection::HasPendingPackages() const {
@@ -179,7 +189,9 @@ asio::awaitable<void> PrimaryConnection::CoSeek(const std::shared_ptr<SSLContext
         asio::post(
             m_context,
             [cb = std::move(callback), listenEndpoint]() mutable {
-                cb(listenEndpoint);
+                if (cb) {
+                    cb(listenEndpoint);
+                }
             }
         );
 
@@ -235,7 +247,13 @@ asio::awaitable<void> PrimaryConnection::CoDisconnect(const std::error_code erro
     Debug::Log("PrimaryConnection: Disconnecting primary connection. Reason: {} (code: {})", errorCode.message(), errorCode.value());
 
     m_connectionState.store(ConnectionState::DISCONNECTING);
+    m_sendFlag.Signal();
+    m_receiveFlag->Signal();
+    ConnectionManager::CancelPendingRequests();
+
     co_await CoCleanupConnection();
+    ClearQueuedPackages();
+    m_heartbeatReceived.store(false);
     m_connectionState.store(ConnectionState::DISCONNECTED);
 
     Debug::Log("PrimaryConnection: Disconnected TLS primary connection successfully.");
@@ -261,7 +279,6 @@ asio::awaitable<void> PrimaryConnection::CoSend() {
 
         while (m_connectionState.load() == ConnectionState::CONNECTED) {
             co_await m_sendFlag.Wait();
-            m_sendFlag.Reset();
 
             std::vector<uint8_t> buffer;
             buffer.resize(PackageHeader::GetSerializedSize());
@@ -425,6 +442,20 @@ void PrimaryConnection::SavePairData(const InitialConnectionData& data) {
     }
 
     Debug::Log("PrimaryConnection: Saved pair data to '{}'", std::filesystem::absolute(targetDataPath).string());
+}
+
+void PrimaryConnection::ClearQueuedPackages() {
+    moodycamel::ConsumerToken outboundToken(m_packageOut);
+    moodycamel::ConsumerToken inboundToken(m_packageIn);
+
+    std::unique_ptr<Package<PC_PackageType>> package;
+    while (m_packageOut.try_dequeue(outboundToken, package)) {
+    }
+
+    while (m_packageIn.try_dequeue(inboundToken, package)) {
+    }
+
+    m_inboundQueuedBytes.store(0);
 }
 
 void PrimaryConnection::SaveCertificate(const InitialConnectionData& data) const {

--- a/utilities/system/inc/AwaitableFlag.h
+++ b/utilities/system/inc/AwaitableFlag.h
@@ -6,6 +6,7 @@
 #include <asio/steady_timer.hpp>
 #include <chrono>
 #include <atomic>
+#include <algorithm>
 
 class AwaitableFlag {
 public:
@@ -27,19 +28,31 @@ public:
     }
 
     asio::awaitable<Result> Wait(const std::chrono::time_point<std::chrono::steady_clock> timeout = asio::steady_timer::time_point::max()) {
-        if (m_flag.load(std::memory_order_acquire))
-            co_return Result::SUCCESS;
+        const bool hasTimeout = timeout != asio::steady_timer::time_point::max();
+        constexpr auto POLL_INTERVAL = std::chrono::milliseconds(250);
 
-        m_timer.expires_at(timeout);
+        while (true) {
+            if (TryConsume()) {
+                co_return Result::SUCCESS;
+            }
 
-        asio::error_code errorCode;
-        co_await m_timer.async_wait(asio::redirect_error(asio::use_awaitable, errorCode));
+            const auto now = std::chrono::steady_clock::now();
+            if (hasTimeout && now >= timeout) {
+                co_return Result::TIMEOUT;
+            }
 
-        if (errorCode == asio::error::operation_aborted && m_flag.load(std::memory_order_acquire)) {
-            co_return Result::SUCCESS;
+            const auto nextWakeTime = hasTimeout
+                ? std::min(timeout, now + POLL_INTERVAL)
+                : now + POLL_INTERVAL;
+            m_timer.expires_at(nextWakeTime);
+
+            asio::error_code errorCode;
+            co_await m_timer.async_wait(asio::redirect_error(asio::use_awaitable, errorCode));
+
+            if (errorCode != asio::error::operation_aborted && hasTimeout && std::chrono::steady_clock::now() >= timeout) {
+                co_return Result::TIMEOUT;
+            }
         }
-
-        co_return Result::TIMEOUT;
     }
 
     template <typename Rep, typename Period>
@@ -49,6 +62,10 @@ public:
     }
 
 private:
+    bool TryConsume() {
+        return m_flag.exchange(false, std::memory_order_acq_rel);
+    }
+
     asio::any_io_executor m_executor;
     asio::steady_timer    m_timer;
     std::atomic<bool>     m_flag;

--- a/utilities/system/inc/ConcurrentUnorderedMap.h
+++ b/utilities/system/inc/ConcurrentUnorderedMap.h
@@ -4,6 +4,7 @@
 #include <unordered_map>
 #include <mutex>
 #include <optional>
+#include <vector>
 
 template<typename Key, typename Value, typename Hash = std::hash<Key>>
 class ConcurrentUnorderedMap final {
@@ -82,6 +83,20 @@ public:
         }
 
         return std::nullopt;
+    }
+
+    std::vector<Value> PopAll() {
+        std::lock_guard<std::mutex> lock(m_mutex);
+
+        std::vector<Value> values;
+        values.reserve(m_map.size());
+
+        for (auto& entry : m_map) {
+            values.push_back(std::move(entry.second));
+        }
+
+        m_map.clear();
+        return values;
     }
 
     bool Assign(const Key& key, Value&& value) {

--- a/utilities/virtual-camera/linux/v4l2loopback-helper.cpp
+++ b/utilities/virtual-camera/linux/v4l2loopback-helper.cpp
@@ -1,6 +1,7 @@
 #include <algorithm>
 #include <cerrno>
 #include <cctype>
+#include <cstdlib>
 #include <iostream>
 #include <string>
 #include <vector>
@@ -9,6 +10,50 @@
 #include <unistd.h>
 
 namespace {
+std::string ResolveExecutablePath(const std::string& executable) {
+    if (executable.empty() || executable.find('/') != std::string::npos) {
+        return executable;
+    }
+
+    std::vector<std::string> searchDirs;
+    if (const char* pathEnv = std::getenv("PATH"); pathEnv != nullptr) {
+        const std::string pathValue = pathEnv;
+        std::size_t start = 0;
+        while (start <= pathValue.size()) {
+            const std::size_t end = pathValue.find(':', start);
+            searchDirs.emplace_back(pathValue.substr(start, end - start));
+            if (end == std::string::npos) {
+                break;
+            }
+            start = end + 1;
+        }
+    }
+
+    for (const char* fallbackDir : {
+             "/usr/local/sbin", "/usr/local/bin",
+             "/usr/sbin", "/usr/bin",
+             "/sbin", "/bin"
+         }) {
+        const std::string directory = fallbackDir;
+        if (std::find(searchDirs.begin(), searchDirs.end(), directory) == searchDirs.end()) {
+            searchDirs.push_back(directory);
+        }
+    }
+
+    for (const std::string& directory : searchDirs) {
+        if (directory.empty()) {
+            continue;
+        }
+
+        const std::string candidate = directory + "/" + executable;
+        if (access(candidate.c_str(), X_OK) == 0) {
+            return candidate;
+        }
+    }
+
+    return executable;
+}
+
 int RunCommand(const std::vector<std::string>& args) {
     if (args.empty()) {
         return 1;
@@ -92,5 +137,6 @@ int main(int argc, char** argv) {
         return 1;
     }
 
+    args[0] = ResolveExecutablePath(args[0]);
     return RunCommand(args);
 }


### PR DESCRIPTION
Introduce an abortable enable flow and various robustness fixes across networking and file-share modules.

- BaseModule: add ShouldAbortEnable(), tighten state checks during enable/disable/shutdown and adjust DisableAwaitable usage.
- FileShare (desktop/mobile): deduplicate/consolidate directory scans (desktop: mutex + in-flight set; mobile: shared_future map via ThreadPool), clear pending scans on disable/shutdown, and switch to awaitable response handler for directory requests.
- Network/Notification modules: early abort checks (ShouldAbortEnable) added at multiple await points to cancel enabling when state changes.
- ConnectionManager/PrimaryConnection/InitialConnection: add request timeout handling (REQUEST_TIMEOUT), CancelPendingRequests(), clear queued packages on disconnect, safer GetPeerAddress(), and ensure send/receive flags are signalled to unblock loops.
- AwaitableFlag: rewrite Wait to poll with a timer and consume the flag atomically (TryConsume) for more reliable waits with timeouts.
- ConcurrentUnorderedMap: add PopAll() helper to extract and clear stored values.
- v4l2loopback-helper: add ResolveExecutablePath to search PATH and common dirs before running command.

These changes improve cancellation, resource cleanup, and concurrency for in-flight requests and module lifecycle transitions.